### PR TITLE
Skip diversity analysis for runs containing too few taxa or individuals

### DIFF
--- a/diversity/diversity.R
+++ b/diversity/diversity.R
@@ -20,25 +20,16 @@ for (dir in dirlist) {
     dirname = strsplit(dir,.Platform$file.sep)[[1]][-1]
     run = strsplit(dirname,'_')[[1]][1]
     message(run)
-    try({
-        otufile = file.path(dirname,"cr_otus",
-                            paste(dirname,"otu_table.txt",sep="_"))
-        otu = read.otu.tsv(otufile)
-        numTaxa = dim(otu)[1]
-        numInd = sum(otu$Count)
-        message(paste("Number of distinct taxa: ",numTaxa,"- Total individuals: ",numInd))
-        if ((numTaxa >= 20)&&(numInd >= 40)) {
-            svg(paste(run,"svg",sep="."))
-            summ = analyseOtu(otu)
-            dev.off()
-            tab = rbind(tab,summ)
-            rownames(tab)[dim(tab)[1]] = run
-            file.rename(from=paste(run,"svg",sep="."),
-                        to=file.path(dirname,"charts","tad-plots.svg"))
-        } else {
-            message("Too few species/individuals: SKIPPING")
-            }
-        })
+    otufile = file.path(dirname,"cr_otus",
+                        paste(dirname,"otu_table.txt",sep="_"))
+    otu = read.otu.tsv(otufile)
+    svg(paste(run,"svg",sep="."))
+    summ = analyseOtu(otu)
+    dev.off()
+    tab = rbind(tab,summ)
+    rownames(tab)[dim(tab)[1]] = run
+    file.rename(from=paste(run,"svg",sep="."),
+                to=file.path(dirname,"charts","tad-plots.svg"))
 }
 df=data.frame("Run"=rownames(tab),tab)
 write.table(df,file.path("project-summary","diversity.tsv"),

--- a/diversity/diversity.R
+++ b/diversity/diversity.R
@@ -20,16 +20,25 @@ for (dir in dirlist) {
     dirname = strsplit(dir,.Platform$file.sep)[[1]][-1]
     run = strsplit(dirname,'_')[[1]][1]
     message(run)
-    otufile = file.path(dirname,"cr_otus",
-                        paste(dirname,"otu_table.txt",sep="_"))
-    otu = read.otu.tsv(otufile)
-    svg(paste(run,"svg",sep="."))
-    summ = analyseOtu(otu)
-    dev.off()
-    tab = rbind(tab,summ)
-    rownames(tab)[dim(tab)[1]] = run
-    file.rename(from=paste(run,"svg",sep="."),
-                to=file.path(dirname,"charts","tad-plots.svg"))
+    try({
+        otufile = file.path(dirname,"cr_otus",
+                            paste(dirname,"otu_table.txt",sep="_"))
+        otu = read.otu.tsv(otufile)
+        numTaxa = dim(otu)[1]
+        numInd = sum(otu$Count)
+        message(paste("Number of distinct taxa: ",numTaxa,"- Total individuals: ",numInd))
+        if ((numTaxa >= 20)&&(numInd >= 40)) {
+            svg(paste(run,"svg",sep="."))
+            summ = analyseOtu(otu)
+            dev.off()
+            tab = rbind(tab,summ)
+            rownames(tab)[dim(tab)[1]] = run
+            file.rename(from=paste(run,"svg",sep="."),
+                        to=file.path(dirname,"charts","tad-plots.svg"))
+        } else {
+            message("Too few species/individuals: SKIPPING")
+            }
+        })
 }
 df=data.frame("Run"=rownames(tab),tab)
 write.table(df,file.path("project-summary","diversity.tsv"),

--- a/diversity/diversity.R
+++ b/diversity/diversity.R
@@ -38,15 +38,22 @@ for (dir in dirlist) {
     message(run)
     tryCatch({
         otu = read.otu.tsv(otufile)
-        svg(paste(run,"svg",sep="."))
-        summ = analyseOtu(otu)
-        dev.off()
-        tab = rbind(tab,summ)
-        rownames(tab)[dim(tab)[1]] = run
-        #added the suffix ("SSU"/"LSU") to the tad plot files
-        file.rename(from=paste(run,"svg",sep="."),
+        numTaxa = dim(otu)[1]
+        numInd = sum(otu$Count)
+        message(paste("Number of distinct taxa: ",numTaxa,"- Total individuals: ",numInd))
+        if ((numTaxa >= 20)&&(numInd >= 40)) {
+            svg(paste(run,"svg",sep="."))
+            summ = analyseOtu(otu)
+            dev.off()
+            tab = rbind(tab,summ)
+            rownames(tab)[dim(tab)[1]] = run
+            ##added the suffix ("SSU"/"LSU") to the tad plot files
+            file.rename(from=paste(run,"svg",sep="."),
                     to=file.path(dirname,"charts",paste(out_file_tag,"tad-plots.svg",sep="")))
-       cat("Processed ",run,"\n",sep="")
+        } else {
+            message("Too few species/individuals: SKIPPING")
+        }
+        cat("Processed ",run,"\n",sep="")
     }, error = function(cond) {if (file.exists(paste(run,"svg",sep="."))) file.remove(paste(run,"svg",sep=".")); cat(paste("Failed on run ",run,": ",cond,"\n",sep=""))})
 }
 #added the suffix ("SSU"/"LSU") to the diversity files


### PR DESCRIPTION
Slight tweak to the script now requiring a run taxa table to include at least 20 taxa and 40 individuals before attempting to conduct a diversity analysis. The 20 and 40 are arbitrary - they work for me on the very small sample of data that I have - they can be tweaked if necessary when run on the full data.